### PR TITLE
Add BUbiNG bot

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -156,6 +156,10 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "BUbiNG",
+    "last_changed": "2018-02-07"
+  },
+  {
     "pattern": "bwh3_user_agent",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
One particular instance of this bot gives the following user agent:

> BUbiNG (+http://law.di.unimi.it/BUbiNG.html)

The page listed gives this information about the bot:

> BUbiNG is a scalable, fully distributed crawler, currently under development and that supersedes UbiCrawler.

This particular instance alone crawls one of my site's from thirty-one different IPv4 addresses in one day.