### PR TITLE
escaping periods for www.gnip.com

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1085,7 +1085,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "www.gnip.com",
+    "pattern": "www\.gnip\.com",
     "last_changed": "2017-08-08"
   },
   {

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1085,7 +1085,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "www\.gnip\.com",
+    "pattern": "www\\.gnip\\.com",
     "last_changed": "2017-08-08"
   },
   {


### PR DESCRIPTION
I think this was just a typo?  Currently its allowing anycharcter, but I think the pattern should be looking exactly for a www.gnip.com instead?