### PR TITLE
COUNTER_Robots_list.json: Add Pcore-HTTP

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -795,6 +795,10 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Pcore\\-HTTP",
+    "last_changed": "2018-07-12"
+  },
+  {
     "pattern": "pear.php.net",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
The user agent `Pcore-HTTP/v0.44.0` makes tens of thousands of requests to URLs forbidden by robots.txt, even though I did see it request robots.txt at least once. I cannot find information about this user agent, but there are many discussion threads complaining about its behavior.

By the way: in my pattern I've double escaped the hyphen. This seems to be how you are adding patterns containing regex metacharacters?