### PR TITLE
Pattern "Ning" is too weak

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -759,8 +759,8 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "Ning",
-    "last_changed": "2017-08-08"
+    "pattern": "^Ning\\/\\d",
+    "last_changed": "2019-08-06"
   },
   {
     "pattern": "no_user_agent",
@@ -916,7 +916,7 @@
     "pattern": "ScoutJet",
     "last_changed": "2019-02-12",
     "url": "http://www.scoutjet.com/"
-  },  
+  },
   {
     "pattern": "^scrutiny\\/\\d",
     "last_changed": "2017-08-08"

--- a/generated/COUNTER_Robots_list.txt
+++ b/generated/COUNTER_Robots_list.txt
@@ -183,7 +183,7 @@ nagios
 netcraft
 netluchs
 ng\/2\.
-Ning
+^Ning\/\d
 no_user_agent
 nomad
 nutch


### PR DESCRIPTION
The pattern "Ning" appears to be too weak when evaluated case-insensitive as advised.

```
  {
    "pattern": "Ning",
    "last_changed": "2017-08-08"
  },
```

It matches the Thunderbird's in-client browser, when the "Lightning" plugin is installed:
```
Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Thunderbird/52.4.0 Lightning/5.4.4
Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Thunderbird/60.8.0 Lightning/6.2.8
Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101 Thunderbird/60.8.0 Lightning/6.2.8
Mozilla/5.0 (Windows NT 6.1; WOW64; rv:60.0) Gecko/20100101 Thunderbird/60.8.0 Lightning/6.2.8
```
