### PR TITLE
Exclude ^Apache-HttpClient user-agent

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -73,6 +73,10 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "^Apache-HttpClient",
+    "last_changed": "2019-08-20"
+  },
+  {
     "pattern": "appie",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
Looking at the documentation, the string to exclude is the default setting for Apache DefaultHttpClient class: https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/DefaultHttpClient.html. Customers have written something in Java and left the default settings on for the useragent.