### PR TITLE
COUNTER_Robots_list.json: Remove unnecessary escaping of dashes

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -44,7 +44,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "A6\\-Indexer",
+    "pattern": "A6-Indexer",
     "last_changed": "2018-09-05",
     "description": "A6 Corp's bot"
   },
@@ -149,7 +149,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "blaiz\\-bee",
+    "pattern": "blaiz-bee",
     "last_changed": "2017-08-08"
   },
   {
@@ -161,11 +161,11 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "boitho\\.com\\-dc",
+    "pattern": "boitho\\.com-dc",
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "bookmark\\-manager",
+    "pattern": "bookmark-manager",
     "last_changed": "2017-08-08"
   },
   {
@@ -649,7 +649,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "mediapartners\\-google",
+    "pattern": "mediapartners-google",
     "last_changed": "2017-08-08"
   },
   {
@@ -817,7 +817,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "Pcore\\-HTTP",
+    "pattern": "Pcore-HTTP",
     "last_changed": "2018-07-12"
   },
   {
@@ -1107,7 +1107,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "weborama\\-fetcher",
+    "pattern": "weborama-fetcher",
     "last_changed": "2019-07-31"
   },
   {
@@ -1139,7 +1139,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "WWW\\-Mechanize",
+    "pattern": "WWW-Mechanize",
     "last_changed": "2017-08-08"
   },
   {


### PR DESCRIPTION
It is not necessary to escape dashes (-) unless they are used in a character class where they could otherwise be used to note a range.

For example, in the expression "[a-z]" the dash indicates a range of characters from a to z. If you wanted to match a literal dash in a character class you would have to use "[a-z\-]", meaning "a to z or a dash". As none of our uses are inside character classes, we do not need to escape them as literals.

I verified this by testing Java's java.util.regex.Pattern as well as several PCRE implementations.

- See: https://www.freeformatter.com/java-regex-tester.html
- See: https://regex101.com/