### PR TITLE
COUNTER_Robots_list.json: Fix escaping of Buck

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -4,7 +4,7 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "^Buck\/[0-9]",
+    "pattern": "^Buck\\/[0-9]",
     "last_changed": "2019-11-19"
   },
   {


### PR DESCRIPTION
Need to double escape the forward slash in the JSON file so it ends up with a single escape in the generated patterns file.