### PR TITLE
COUNTER_Robots_list.json: Remove anchors from okhttp

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -815,8 +815,8 @@
     "last_changed": "2020-07-02"
   }, 
   {
-    "pattern": "^okhttp$",
-    "last_changed": "2018-02-15",
+    "pattern": "okhttp",
+    "last_changed": "2020-02-25",
     "description": "okhttp is a Java HTTP client library.",
     "url": "http://square.github.io/okhttp/"
   },


### PR DESCRIPTION
The okhttp library now uses version strings in its user agent so we should not anchor the string with ^ and $. For example, I have seen both of these recently:

    okhttp/3.11.0
    okhttp/3.10.0

We could add a `/\d` to match the version string, but I think that the "okhttp" is unique enough by itself to not be confused with a real human user agent.

See #9