### PR TITLE
COUNTER_Robots_list.json: Escape literal dots

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -661,7 +661,8 @@
     "last_changed": "2018-12-13"
   },
   {
-    "pattern": "mail.ru",
+    "pattern": "mail\\.ru",
+    "url": "https://help.mail.ru/webmaster/indexing/robots.txt/rules/user-agent",
     "last_changed": "2017-08-08"
   },
   {
@@ -845,7 +846,7 @@
     "last_changed": "2019-11-19"
   },
   {
-    "pattern": "pear.php.net",
+    "pattern": "pear\\.php\\.net",
     "last_changed": "2017-08-08"
   },
   {
@@ -1095,7 +1096,9 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "w3af.org",
+    "pattern": "w3af\\.org",
+    "description": "Web Application Attack and Audit Framework",
+    "url": "https://w3af.org/",
     "last_changed": "2017-08-08"
   },
   {


### PR DESCRIPTION
Some patterns are incorrect because they mean to use a literal dot, but we should technically be escaping these to use literal dots in regex. The dot in the `virus.detector` pattern seems to be intentional, as this user agent sometimes appears as `virus-detector` and other times as `virus_detector` from what I can see in other block lists (I have not seem this bot myself). Note that we need to escape the first backslash in the JSON so we can get a literal backslash for escaping the dots in the output file.

Also I've taken the liberty to add URLs and descriptions where applicable.