### PR TITLE
Add new bots

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -316,6 +316,11 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Drupal",
+    "last_changed": "2020-07-20",
+    "description": "Drupal is a content management system. Some Drupal instances perform harvesting or crawling of web resources and should be ignored."
+  },
+  {
     "pattern": "DSurf",
     "last_changed": "2017-08-08"
   },

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1035,6 +1035,11 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Typhoeus",
+    "last_changed": "2020-02-25",
+    "url": "https://github.com/typhoeus/typhoeus"
+  },
+  {
     "pattern": "ucsd",
     "last_changed": "2017-08-08"
   },

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -211,6 +211,11 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Citoid",
+    "last_changed": "2020-02-25",
+    "url": "https://www.mediawiki.org/wiki/Citoid"
+  },
+  {
     "pattern": "cloakDetect",
     "last_changed": "2017-08-08"
   },

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -846,6 +846,11 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "^Pattern\\/\\d",
+    "last_changed": "2020-02-25",
+    "url": "https://www.clips.uantwerpen.be/pattern"
+  },
+  {
     "pattern": "Pcore-HTTP",
     "last_changed": "2019-11-19"
   },

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1216,5 +1216,11 @@
   {
     "pattern": "zyborg",
     "last_changed": "2017-08-08"
+  },
+  {
+    "pattern": "7siters",
+    "last_changed": "2020-02-25",
+    "url": "https://7ooo.ru/siters"
   }
+
 ]

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -987,6 +987,11 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "sqlmap",
+    "last_changed": "2020-02-25",
+    "url": "https://github.com/sqlmapproject/sqlmap"
+  },
+  {
     "pattern": "Strider",
     "last_changed": "2017-08-08"
   },

--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1046,6 +1046,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Turnitin",
+    "last_changed": "2020-07-01",
+    "description": "This robot collects content from the Internet for the sole purpose of helping educational institutions prevent plagiarism.",
+    "url": "https://turnitin.com/robot/crawlerinfo.html"
+  },
+  {
     "pattern": "twiceler",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
This adds patterns to match the following robot user agents:

- Citoid
- Typhoeus
- 7siters
- sqlmap
- Pattern
- OgScrper
- Turnitin
- Drupal

Relevant URLs for each user agent included in the patterns file.

_Note: I had added a few of these in #34 but only a few were merged. I will re-submit them again here._