### PR TITLE
COUNTER_Robots_list.json: Modify daum entry

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -286,8 +286,9 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "daumoa",
-    "last_changed": "2017-08-08"
+    "pattern": "daum(oa)?",
+    "last_changed": "2020-09-10",
+    "url": "https://cs.daum.net/faq/15/4118.html?faqId=28966"
   },
   {
     "pattern": "^\\%?default\\%?$",


### PR DESCRIPTION
This is a Korean spider that apparently used to use the "daumoa" UA but now uses "daum". See an entry in my logs from 2020-08:

Mozilla/5.0 (compatible; Daum/4.1; +http://cs.daum.net/faq/15/4118.html?faqId=28966)

I have modified the user agent pattern to check for both daum and daumoa.