### PR TITLE
Added SrceDAMP robot

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1003,6 +1003,11 @@
     "url": "https://github.com/sqlmapproject/sqlmap"
   },
   {
+    "pattern": "SrceDAMP",
+    "last_changed": "2020-20-10",
+    "url": "https://haw.nsk.hr/en/frequently-asked-questions/"
+  },
+  {
     "pattern": "Strider",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
Added "SrceDAMP" robot of Croatian Web Archive. Details: https://haw.nsk.hr/en/frequently-asked-questions/ under "What are the settings of the Croatian Web Archive crawler?"