### PR TITLE
Added Slack Robot Pattern

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -991,6 +991,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Slack",
+    "last_changed": "2021-04-15",
+    "description": "Slack bots fetching pages for OpenGraph and proxying images",
+    "url": "https://api.slack.com/robots"
+  },
+  {
     "pattern": "slurp",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
The default `Slackbot` will be captured by the `bot` pattern. However, Slack has an additional bot that does not contain the `bot` keyword: `Slack-ImgProxy`. This PR adds the keyword `Slack` to capture all Slack Bots defined in the Slack API documentation https://api.slack.com/robots