### PR TITLE
COUNTER_Robots_list.json: Add two new bots

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -270,6 +270,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "crusty",
+    "last_changed": "2021-06-22",
+    "description": "Crusty web crawler",
+    "url": "https://github.com/let4be/crusty"
+  },
+  {
     "pattern": "curl\\/",
     "last_changed": "2017-08-08"
   },
@@ -787,6 +793,12 @@
   {
     "pattern": "netluchs",
     "last_changed": "2017-08-08"
+  },
+  {
+    "pattern": "newspaper",
+    "last_changed": "2021-06-22",
+    "description": "Python 3 library for news, full-text, and article metadata extraction.",
+    "url": "https://github.com/codelucas/newspaper"
   },
   {
     "pattern": "ng\\/2\\.",


### PR DESCRIPTION
This adds two new bot user agents: crusty and newspaper. These two non-human user agents have made thousands of requests to my server with the following user agents:

- crusty/0.12.0
- newspaper/0.2.8

See the patterns file for more information about each. I have manually verified the user agents in both of these by looking at their source code.

Please let me know if you would like me to adjust the patterns to include further regex metacharacters like digits.