### PR TITLE
COUNTER_Robots_list.json: Add MaCoCu

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -683,6 +683,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "MaCoCu",
+    "last_changed": "2021-08-08",
+    "description": "The aim of MaCoCu, a CEF-funded project, is to collect, curate and enrich monolingual and parallel data from the Internet for 12 under-resourced languages of EU member states and candidate states.",
+    "url": "https://www.clarin.si/info/macocu-massive-collection-and-curation-of-monolingual-and-bilingual-data/"
+  },
+  {
     "pattern": "MarcEdit",
     "last_changed": "2019-12-12"
   },


### PR DESCRIPTION
This is an academic research bot funded by the EU. It is currently using the following user agent:

> Mozilla/5.0 (compatible; MaCoCu; +https://www.clarin.si/info/macocu-massive-collection-and-curation-of-monolingual-and-bilingual-data/)