### PR TITLE
COUNTER_Robots_list.json: Add httpx user agent

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -532,6 +532,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "httpx",
+    "last_changed": "2021-08-12",
+    "description": "httpx is a fast and multi-purpose HTTP toolkit for OSINT.",
+    "url": "https://github.com/projectdiscovery/httpx"
+  },
+  {
     "pattern": "httrack",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
This seems to be some kind of client designed for gathering open-source intelligence for white, gray, and black-hat hacking. The client currently presents the following user-agent header:

> httpx - Open-source project (github.com/projectdiscovery/httpx)

See: https://github.com/projectdiscovery/httpx