### PR TITLE
Add Zabbix user agent

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -1264,6 +1264,11 @@
     "url": "http://naver.me/spd"
   },
   {
+    "pattern": "Zabbix",
+    "description": "Application performance monitoring tool",
+    "last_changed": "2021-11-11"
+  },
+  {
     "pattern": "zeus",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
### Request to add Zabbix to COUNTER-Robots list

At my institution, we currently use Zabbix to monitor the health of our OJS journals (among other things). Unfortunately, because of the way Zabbix works, it shows up in our usage OJS (version 3.2.1-4) statistics and heavily distorts actual usage. While Zabbix is a legitimate tool for monitoring the health of web servers, it should probably never show up in usage stats. This addition to the COUNTER-Robots list should also benefit other institutions that make use of Zabbix for APM.

For more information about Zabbix, see: https://www.zabbix.com/ or https://github.com/zabbix/zabbix