### PR TITLE
COUNTER_Robots_list.json: add HeadlessChrome

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -516,6 +516,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "HeadlessChrome",
+    "last_changed": "2021-12-07",
+    "description": "Headless Chrome is used to automate Chrome requests for testing purposes.",
+    "url": "https://developers.google.com/web/updates/2017/04/headless-chrome"
+  },
+  {
     "pattern": "HttpComponents\\/1.1",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
This user agent is used by Chromium-based browsers when running in headless mode, for example via Puppeteer or Selenium. In our case we have tens of thousands of requests with this user agent from IP addresses owned by Microsoft (it could be users on Azure?).

The user agent appears like this:

> Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/88.0.4298.0 Safari/537.36

See: https://developers.google.com/web/updates/2017/04/headless-chrome