### PR TITLE
COUNTER_Robots_list.json: add koha

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -597,6 +597,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "Koha",
+    "last_changed": "2021-12-29",
+    "description": "Scan all URLs found in of Koha records and displays if resources are available or not.",
+    "url": "https://wiki.koha-community.org/wiki/Check-url_enhancements"
+  },
+  {
     "pattern": "kyluka",
     "last_changed": "2017-08-08"
   },


### PR DESCRIPTION
This is the user agent used by the Koha library system to check if links in library resources are available. I see the following user agent in requests made by this client:

```console
Mozilla/5.0 (compatible; U; Koha checkurl)
```

See: https://wiki.koha-community.org/wiki/Check-url_enhancements
See: https://github.com/Koha-Community/Koha/blob/master/misc/cronjobs/check-url-quick.pl