### PR TITLE
New entries for nettle and centurybot

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -201,6 +201,10 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "centuryb",
+    "last_changed": "2022-04-27"
+  },
+  {
     "pattern": "cfnetwork",
     "last_changed": "2017-08-08"
   },
@@ -832,6 +836,12 @@
   {
     "pattern": "netluchs",
     "last_changed": "2017-08-08"
+  },
+  {
+    "pattern": "nettle",
+    "last_changed": "2022-04-27",
+    "description": "AI company, doing natural language processing.",
+    "url": "https://www.nettle.sk"
   },
   {
     "pattern": "newspaper\\/\\d",


### PR DESCRIPTION
observed entries in logs:

nettle (+https://www.nettle.sk)
Mozilla/5.0 (compatible; +centuryb.o.t9[at]gmail.com)