### PR TITLE
COUNTER_Robots_list.json: Add new bots

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -584,6 +584,12 @@
     "last_changed": "2017-08-08"
   },
   {
+    "pattern": "insomnia",
+    "last_changed": "2022-05-04",
+    "description": "The open-source, cross-platform API client for GraphQL, REST, and gRPC.",
+    "url": "https://github.com/Kong/insomnia"
+  },
+  {
     "pattern": "^integrity\\/\\d",
     "last_changed": "2017-08-08"
   },
@@ -732,6 +738,12 @@
   {
     "pattern": "megite",
     "last_changed": "2017-08-08"
+  },
+  {
+    "pattern": "MetaInspector",
+    "last_changed": "2022-05-04",
+    "description": "Ruby gem for web scraping purposes.",
+    "url": "https://github.com/metainspector/metainspector"
   },
   {
     "pattern": "MetaURI[\\+\\s]API\\/\\d\\.\\d",
@@ -981,6 +993,12 @@
   {
     "pattern": "redalert",
     "last_changed": "2017-08-08"
+  },
+  {
+    "pattern": "RestSharp",
+    "last_changed": "2022-05-04",
+    "description": "Simple REST and HTTP API Client for .NET",
+    "url": "https://github.com/restsharp/RestSharp"
   },
   {
     "pattern": "Riddler",


### PR DESCRIPTION
The following non-human user agents were seen in my web server logs recently:

- `RestSharp/106.11.7.0`
- `MetaInspector/5.7.0 (+https://github.com/jaimeiniesta/metainspector)`
- `insomnia/2022.2.1`

All appear to be packages for interacting with web services programmatically. Links to project sites in the updated JSON file.