### PR TITLE
COUNTER_Robots_list.json: update java pattern

### DIFF
--- a/COUNTER_Robots_list.json
+++ b/COUNTER_Robots_list.json
@@ -626,8 +626,8 @@
     "last_changed": "2017-08-08"
   },
   {
-    "pattern": "^java\\/\\d{1,2}.\\d",
-    "last_changed": "2017-08-08"
+    "pattern": "^java",
+    "last_changed": "2024-01-29"
   },
   {
     "pattern": "jeeves",


### PR DESCRIPTION
We can uniquely identify any java user agent by checking for `^java` with no version. The previous pattern assumed all java versions were 1.x, and failed to escape the dot anyway.